### PR TITLE
Z-Index update for Button (It comes from NS 6)

### DIFF
--- a/components/Star.vue
+++ b/components/Star.vue
@@ -81,5 +81,6 @@ export default {
     0% 35%,
     39% 35%
   );
+  z-index: 0;
 }
 </style>


### PR DESCRIPTION
Hi, in NativeScript 6 now button always have a "z-index", which makes Button appear to have depth.
In order to dismiss this look, we need to set 'z-index: 0', and that's what I made.

I hope it was helpful!

Best Regards,
Gabriel S.