### PR TITLE
Size fix: replace px with DIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Use in template:
 ...  
 <StarRating :value="rating" size="90" />  
 ...  
+```
+
+I found that in {NS}6+ the size attribute either doesn't work or it deforms the stars.
+Therefore a solution is to use:
+
+```xml
+<StarRating :value="rating" scaleX="0.8" scaleY="0.8" />
+
 ```   
 
 ## Properties  
@@ -38,11 +46,11 @@ Use in template:
 | Prop             | Type            | Description                                        | Default Value  |  
 |:----------------:|:---------------:| -------------------------------------------------- | -------------- |  
 | **value** | Number          | The rating value                                   |  1             |  
-| **size** | String, Number  | Size in pixels of width and height of the star     | 75             |  
+| **size** | String, Number  | Size in DIP* of width and height of the star     | 75             |  
 | **fillColor** | String          | CSS color for the filled stars                     | <span style="color:#FFEB0A">'#FFEB0A'</span>      |  
 | **emptyColor** | String          | CSS color for the empty stars                      | <span style="color:#ABABAB">'#ABABAB'</span>      |  
 | **outlineColor** | String          | CSS color for the star outline                     | <span style="color:#000">'#000'</span>            |  
-  
+* DIP - device independent pixels  
 ## Events  
   
 | Event              | Returns | Description                                    |  

--- a/components/Star.vue
+++ b/components/Star.vue
@@ -39,8 +39,8 @@ export default {
   computed: {
     starStyle() {
       return {
-        width: `${this.size}px`,
-        height: `${this.size}px`,
+        width: `${this.size}`,
+        height: `${this.size}`,
         background: `linear-gradient(90deg, ${this.fillColor} ${
           this.percentage
         }, ${this.emptyColor} ${this.percentage})`

--- a/components/Star.vue
+++ b/components/Star.vue
@@ -12,7 +12,7 @@ export default {
     size: {
       type: [String, Number],
       required: false,
-      default: 15
+      default: 30
     },
     fillColor: {
       type: String,

--- a/components/Star.vue
+++ b/components/Star.vue
@@ -12,7 +12,7 @@ export default {
     size: {
       type: [String, Number],
       required: false,
-      default: 75
+      default: 15
     },
     fillColor: {
       type: String,

--- a/components/StarRating.vue
+++ b/components/StarRating.vue
@@ -25,7 +25,7 @@ export default {
     size: {
       type: [String, Number],
       required: false,
-      default: 75
+      default: 15
     },
     fillColor: {
       type: String,

--- a/components/StarRating.vue
+++ b/components/StarRating.vue
@@ -25,7 +25,7 @@ export default {
     size: {
       type: [String, Number],
       required: false,
-      default: 15
+      default: 30
     },
     fillColor: {
       type: String,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "t",
+  "version": "0.0.5",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/panietoar/nativescript-vue-star-rating.git"
+    "url": "git+https://github.com/Rho-bur/nativescript-vue-star-rating.git"
   },
   "keywords": [
     "nativescript",
@@ -19,11 +19,17 @@
   ],
   "author": "Pablo nieto (panietoar@gmail.com)",
   "license": "MIT",
+  "nativescript": {
+    "platforms": {
+      "android": "6.5.3",
+      "ios": "6.5.2"
+    }
+  },
   "peerDependencies": {
     "tns-core-modules": "*"
   },
   "bugs": {
-    "url": "https://github.com/panietoar/nativescript-vue-star-rating/issues"
+    "url": "https://github.com/Rho-bur/nativescript-vue-star-rating/issues"
   },
-  "homepage": "https://github.com/panietoar/nativescript-vue-star-rating#readme"
+  "homepage": "https://github.com/Rho-bur/nativescript-vue-star-rating/blob/master/README.md"
 }


### PR DESCRIPTION
In {NS}6+ the size attribute didn't work for me in any minor version, either having no effect upon changing or distorting the stars layout.
Replacing the px units with DIP and using the `scaleX` `scaleY` instead of `size` in the Vue component solved my issue. 